### PR TITLE
Fix run_export indentation bug and add brain export support

### DIFF
--- a/brain/views.py
+++ b/brain/views.py
@@ -14,7 +14,7 @@ from django.urls import reverse
 from django.views.decorators.http import require_http_methods, require_POST
 from django.http import JsonResponse
 
-from common.file_access import exists as artifact_exists
+from common.file_access import exists as artifact_exists, streaming_response
 from common.models import FileRegistry, Job, Modality, Project, ProjectAccess
 from common.object_storage import get_object_storage
 from common.permissions import (
@@ -995,7 +995,45 @@ def export_list(request):
 @_with_brain_export_mappings
 def export_new(request):
     if request.method == "POST":
-        export = Export.objects.create(user=request.user, status="pending", query_params=dict(request.POST), query_summary="Brain export")
+        folder_ids = [int(fid) for fid in request.POST.getlist("folder_ids")]
+        modality_slugs = request.POST.getlist("modality_slugs")
+
+        if not folder_ids:
+            messages.error(request, "Please select at least one folder.")
+            return redirect("brain:export_new")
+        if not modality_slugs:
+            messages.error(request, "Please select at least one modality.")
+            return redirect("brain:export_new")
+
+        filters = {
+            key.replace("filter_", ""): True
+            for key in request.POST.keys()
+            if key.startswith("filter_")
+        }
+
+        query_params = {
+            "domain": "brain",
+            "folder_ids": folder_ids,
+            "modality_slugs": modality_slugs,
+            "filters": filters,
+        }
+        # Content selection: pass through only if the form provides it; otherwise
+        # the processor defaults to raw + processed (legacy behavior).
+        for key in ("include_raw", "include_processed", "include_reports"):
+            if key in request.POST:
+                query_params[key] = request.POST.get(key) in ("1", "true", "on", "yes")
+
+        export = Export.objects.create(
+            user=request.user,
+            status="pending",
+            query_params=query_params,
+            query_summary=f"{len(folder_ids)} folder(s), {len(modality_slugs)} modality(ies)",
+        )
+
+        from maxillo.utils.export_processor import start_export_processing
+
+        start_export_processing(export.id, "brain")
+
         messages.success(request, f"Export #{export.id} created.")
         return redirect("brain:export_list")
     folders = filter_folders_for_user(request.user, Folder.objects.filter(parent__isnull=True), "brain")
@@ -1016,7 +1054,31 @@ def export_status(request, export_id):
 
 @login_required
 def export_download(request, export_id):
-    return JsonResponse({"error": "Brain export download is not implemented in the decoupled view yet."}, status=501)
+    export = get_object_or_404(Export, id=export_id)
+
+    if export.user != request.user and not request.user.is_staff:
+        messages.error(request, "You do not have permission to download this export.")
+        return redirect("brain:export_list")
+
+    if export.status != "completed":
+        messages.error(request, "Export is not yet completed.")
+        return redirect("brain:export_list")
+
+    if not export.file_path or not artifact_exists(export.file_path):
+        messages.error(request, "Export file not found.")
+        export.mark_failed("Export file not found in storage")
+        return redirect("brain:export_list")
+
+    filename = (
+        os.path.basename((export.file_path or "").rstrip("/"))
+        or f"export_{export.id}.zip"
+    )
+    return streaming_response(
+        path_or_key=export.file_path,
+        content_type="application/zip",
+        filename=filename,
+        as_attachment=True,
+    )
 
 
 @login_required

--- a/maxillo/management/commands/run_export.py
+++ b/maxillo/management/commands/run_export.py
@@ -18,17 +18,23 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('export_id', type=int)
+        parser.add_argument('--domain', choices=['maxillo', 'laparoscopy', 'brain'])
 
-parser.add_argument('--domain', choices=['maxillo', 'laparoscopy'])
     def handle(self, *args, **options):
+        from brain.models import Export as BrainExport
+
         export_id = options['export_id']
         domain = options.get('domain')
+
         export = None
         if domain == 'laparoscopy':
             export = LaparoscopyExport.objects.filter(id=export_id).first()
+        elif domain == 'brain':
+            export = BrainExport.objects.filter(id=export_id).first()
         elif domain == 'maxillo':
             export = MaxilloExport.objects.filter(id=export_id).first()
         else:
+            # No domain given: probe each table and infer the domain.
             export = MaxilloExport.objects.filter(id=export_id).first()
             if export:
                 domain = 'maxillo'
@@ -36,16 +42,13 @@ parser.add_argument('--domain', choices=['maxillo', 'laparoscopy'])
                 export = LaparoscopyExport.objects.filter(id=export_id).first()
                 if export:
                     domain = 'laparoscopy'
+                else:
+                    export = BrainExport.objects.filter(id=export_id).first()
+                    if export:
+                        domain = 'brain'
 
-        export = MaxilloExport.objects.filter(id=export_id).first()
         if not export:
             raise CommandError(f'Export {export_id} not found')
-
-        if not domain:
-            if export.__class__.__module__.startswith('laparoscopy.'):
-                domain = 'laparoscopy'
-            else:
-                domain = 'maxillo'
 
         if export.status == 'pending':
             export.mark_processing()

--- a/maxillo/utils/export_processor.py
+++ b/maxillo/utils/export_processor.py
@@ -60,6 +60,15 @@ class ExportProcessor:
         """Initialize processor with export instance."""
         self.export = export
         self.domain = domain
+        # Domain-specific modality->file-type map and FileRegistry patient FK.
+        if domain == "brain":
+            from brain.export_config import BRAIN_EXPORT_MODALITY_FILE_TYPES
+
+            self.modality_map = BRAIN_EXPORT_MODALITY_FILE_TYPES
+            self.patient_fk = "brain_patient"
+        else:
+            self.modality_map = self.MODALITY_TO_FILE_TYPES
+            self.patient_fk = "patient"
         self.query_params = export.query_params
         self.folder_ids = self.query_params.get("folder_ids", [])
         # Strip legacy "reports" pseudo-slug from modality list
@@ -99,7 +108,7 @@ class ExportProcessor:
         return str(value).strip().lower() in {"1", "true", "yes", "on"}
 
     def _modality_file_type_groups(self, modality_slug):
-        return self.MODALITY_TO_FILE_TYPES.get(
+        return self.modality_map.get(
             modality_slug, {"raw": [], "processed": []}
         )
 
@@ -146,7 +155,9 @@ class ExportProcessor:
     def _patient_file_queryset(self, patients):
         from common.models import FileRegistry
 
-        return FileRegistry.objects.filter(domain="maxillo", patient__in=patients)
+        return FileRegistry.objects.filter(
+            domain=self.domain, **{f"{self.patient_fk}__in": patients}
+        )
 
     def _build_no_files_found_error(self, patients):
         selected_content = []
@@ -194,9 +205,29 @@ class ExportProcessor:
             message += " Tip: enable Raw files if post-processing has not finished yet."
         return message
 
+    def _domain_models(self):
+        """Return (Patient, VoiceCaption) model classes for the active domain."""
+        if self.domain == "brain":
+            from brain.models import Patient, VoiceCaption
+        else:
+            from ..models import Patient, VoiceCaption
+        return Patient, VoiceCaption
+
+    def _filter_patients_by_folders(self, Patient):
+        """Base patient queryset restricted to the requested folders.
+
+        maxillo links a patient to a single folder via the `folder` FK, while
+        brain uses a `folders` many-to-many relationship.
+        """
+        if not self.folder_ids:
+            return Patient.objects.none()
+        if self.domain == "brain":
+            return Patient.objects.filter(folders__id__in=self.folder_ids).distinct()
+        return Patient.objects.filter(folder_id__in=self.folder_ids)
+
     def _update_progress(self, message, percent=None):
         """Update progress on the Export record for live feedback."""
-        from ..models import Export
+        Export = self.export.__class__
 
         update_kw = {"progress_message": message}
         if percent is not None:
@@ -205,16 +236,12 @@ class ExportProcessor:
 
     def query_patients(self):
         """Query patients based on folder_ids and filters. Apply AND logic for all filters."""
-        from ..models import Patient, VoiceCaption
+        Patient, VoiceCaption = self._domain_models()
 
         from common.models import FileRegistry, Modality
 
-        # Start with folder filter
-        patients = (
-            Patient.objects.filter(folder_id__in=self.folder_ids)
-            if self.folder_ids
-            else Patient.objects.none()
-        )
+        # Start with folder filter (FK for maxillo, M2M for brain)
+        patients = self._filter_patients_by_folders(Patient)
 
         if not patients.exists():
             return patients
@@ -280,7 +307,7 @@ class ExportProcessor:
 
     def collect_files(self, patients):
         """Collect files from FileRegistry for each patient and selected modalities."""
-        from ..models import VoiceCaption
+        _Patient, VoiceCaption = self._domain_models()
 
         from common.models import FileRegistry, Modality
 
@@ -332,7 +359,9 @@ class ExportProcessor:
                     query |= Q(modality__in=modality_objects) & content_query
 
             patient_files = (
-                FileRegistry.objects.filter(domain="maxillo", patient=patient)
+                FileRegistry.objects.filter(
+                    domain=self.domain, **{self.patient_fk: patient}
+                )
                 .filter(query)
                 .distinct()
             )
@@ -700,11 +729,14 @@ def start_export_processing(export_id, domain="maxillo"):
     after the HTTP request ends (web workers can recycle and kill threads).
     """
 
+    from brain.models import Export as BrainExport
     from laparoscopy.models import Export as LaparoscopyExport
     from ..models import Export as MaxilloExport
     try:
         if domain == "laparoscopy":
             export = LaparoscopyExport.objects.filter(id=export_id).first()
+        elif domain == "brain":
+            export = BrainExport.objects.filter(id=export_id).first()
         else:
             export = MaxilloExport.objects.filter(id=export_id).first()
         if not export:
@@ -737,9 +769,12 @@ def start_export_processing(export_id, domain="maxillo"):
     except Exception as e:
         logger.error(f"Error starting export processing: {e}", exc_info=True)
         try:
-            export = MaxilloExport.objects.filter(
-                id=export_id
-            ).first() or LaparoscopyExport.objects.filter(id=export_id).first() or BrainExport.objects.get(id=export_id)
-            export.mark_failed(str(e))
+            export = (
+                MaxilloExport.objects.filter(id=export_id).first()
+                or LaparoscopyExport.objects.filter(id=export_id).first()
+                or BrainExport.objects.filter(id=export_id).first()
+            )
+            if export:
+                export.mark_failed(str(e))
         except Exception:
             pass


### PR DESCRIPTION
run_export.py had a misindented `--domain` argument that broke the module import, failing every export. Also removed an unconditional reassignment to the maxillo Export that clobbered the domain-aware lookup for non-maxillo domains.

Generalized maxillo ExportProcessor to be domain-parametric for maxillo + brain (modality map, FileRegistry domain + patient FK, progress table, domain models, folder filtering seam for brain's M2M folders). Laparoscopy keeps its own processor.

Wired brain export views: export_new now builds query_params and starts background processing; export_download streams the ZIP instead of returning 501.